### PR TITLE
diffusers.models to diffusers.models.unets

### DIFF
--- a/code/models.py
+++ b/code/models.py
@@ -3,7 +3,7 @@ import torch.nn.functional as F
 from diffusers import DDIMScheduler  # , DDPMScheduler
 from diffusers import AudioLDMPipeline, AudioLDM2Pipeline, StableDiffusionPipeline
 from transformers import RobertaTokenizer, RobertaTokenizerFast
-from diffusers.models.unet_2d_condition import UNet2DConditionOutput
+from diffusers.models.unets.unet_2d_condition import UNet2DConditionOutput
 import os
 from huggingface_hub import snapshot_download
 import json


### PR DESCRIPTION
For compatibility with diffusers 0.29.0 and up, UNet2DConditionOutput must be imported from diffusers.models.unets.unet_2d_condition instead of diffusers.models.unet_2d_condition